### PR TITLE
Updates to OOOO command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 private
 persistence
 *.iml

--- a/command/oooo.go
+++ b/command/oooo.go
@@ -1,21 +1,76 @@
 package command
 
+import (
+	"strings"
+)
+
+func isVowel(char byte) bool {
+	switch char {
+	case 'a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U':
+		return true
+	default:
+		return false
+	}
+}
+
 type OoooCommand struct{}
 
 func (oc *OoooCommand) Name() string {
 	return "oooo"
 }
 
+// Handle OOOO-ifying a provided string
+// - replace any "o"s if they exist
+// - if no "o"s exist, try to replace the vowel(s) closest to the center of the word
 func (oc *OoooCommand) Handle(message string) (string, error) {
 	oooo := ""
-	for _, ch := range message {
-		if ch == 'o' || ch == 'O' {
-			oooo += " OOOO "
+	if strings.Contains(strings.ToLower(message), "o") {
+		for _, ch := range message {
+			if ch == 'o' || ch == 'O' {
+				oooo += " OOOO "
+			} else {
+				oooo += string(ch)
+			}
+		}
+	} else {
+		messageLength := len(message)
+		midpoint := messageLength / 2
+		vowelIndex := -1
+		if isVowel(message[midpoint]) {
+			vowelIndex = midpoint
 		} else {
-			oooo += string(ch)
+			// Search outwards to find the vowel closest to the center
+			for i := 1; i < messageLength-midpoint; i++ {
+				if beforeIndex := midpoint - i; (beforeIndex) > 0 && isVowel(message[beforeIndex]) {
+					vowelIndex = beforeIndex
+					break
+				} else if afterIndex := midpoint + i; isVowel(message[afterIndex]) {
+					vowelIndex = afterIndex
+					break
+				}
+			}
+		}
+
+		if vowelIndex == -1 {
+			return "Can't find any vowels to replace MMMM", nil
+		}
+
+		// Check if adjacent letters are vowels
+		lowerIndex := vowelIndex
+		upperIndex := vowelIndex
+		if vowelIndex > 0 && isVowel(message[vowelIndex-1]) {
+			lowerIndex = vowelIndex - 1
+		} else if vowelIndex+1 < messageLength && isVowel(message[vowelIndex+1]) {
+			upperIndex = vowelIndex + 1
+		}
+
+		oooo = message[:lowerIndex] + " OOOO "
+		if upperIndex+1 < messageLength {
+			oooo += message[upperIndex+1:]
 		}
 	}
-	return oooo, nil
+
+	return strings.TrimSpace(oooo), nil
 }
 
 func (oc *OoooCommand) RequiresMod() bool {

--- a/command/oooo_test.go
+++ b/command/oooo_test.go
@@ -1,0 +1,77 @@
+package command
+
+import "testing"
+
+func TestOoooCommand_Handle(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "contains o",
+			message: "rhino",
+			want:    "rhin OOOO",
+		},
+		{
+			name:    "does not contain o",
+			message: "thistle",
+			want:    "th OOOO stle",
+		},
+		{
+			name:    "multiple non-o vowel candidates favors the earlier one",
+			message: "jaden",
+			want:    "j OOOO den",
+		},
+		{
+			name:    "multiple non-o vowels adjacent to each other",
+			message: "cheese",
+			want:    "ch OOOO se",
+		},
+		{
+			name:    "non-o vowel at the end of string",
+			message: "hi",
+			want:    "h OOOO",
+		},
+		{
+			name:    "short message",
+			message: "i",
+			want:    "OOOO",
+		},
+		{
+			name:    "does not contain vowels",
+			message: "xkcd",
+			want:    "Can't find any vowels to replace MMMM",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oc := &OoooCommand{}
+			got, err := oc.Handle(tt.message)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Handle() error = %v, wantErr %v", err != nil, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("Handle() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOoooCommand_Name(t *testing.T) {
+	oc := &OoooCommand{}
+	expected := "oooo"
+
+	if result := oc.Name(); result != expected {
+		t.Errorf("Name() = %v, want %v", result, expected)
+	}
+}
+
+func TestOoooCommand_RequiresMod(t *testing.T) {
+	oc := &OoooCommand{}
+
+	if result := oc.RequiresMod(); result != false {
+		t.Errorf("RequiresMod() = %v, want %v", result, false)
+	}
+}


### PR DESCRIPTION
This makes updates to the `!oooo` command to support words that do not contain "o", using my interpretation of how people have been using "OOOO" in Twitch chat names.

If no "o" is found, we'll try to locate the vowel closest to the center of the word, slightly favoring vowels that are before the center.
We'll also try to capture up to one additional adjacent vowel if there is one.